### PR TITLE
Bugfix/supervisord shouldnt try to start application if config file dont exists

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ notifications:
 cache: pip
 
 install:
-- pip install pyrsistent==0.16.0
 - pip install tox tox-venv
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ cache: pip
 install:
 - pip install tox tox-venv
 
-
 before_script:
   # Disable IPv6. Ref travis-ci/travis-ci#8361
   - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,9 @@ notifications:
 cache: pip
 
 install:
+- pip install pyrsistent==0.16.0
 - pip install tox tox-venv
+
 
 before_script:
   # Disable IPv6. Ref travis-ci/travis-ci#8361

--- a/vr/common/models.py
+++ b/vr/common/models.py
@@ -48,8 +48,8 @@ SUPERVISOR_RPC_N_RETRIES = 2
 
 class TimeoutTransport(xmlrpc_client.Transport):
 
-    def __init__(self, timeout=SUPERVISOR_RPC_TIMEOUT_SECS, *l, **kw):
-        xmlrpc_client.Transport.__init__(self, *l, **kw)
+    def __init__(self, timeout=SUPERVISOR_RPC_TIMEOUT_SECS, *t, **kw):
+        xmlrpc_client.Transport.__init__(self, *t, **kw)
         self.timeout = timeout
 
     def make_connection(self, *args, **kwargs):

--- a/vr/common/slugignore.py
+++ b/vr/common/slugignore.py
@@ -70,7 +70,7 @@ def get_slugignores(root, fname='.slugignore'):
     """
     try:
         with open(os.path.join(root, fname)) as f:
-            return [l.rstrip('\n') for l in f]
+            return [line.rstrip('\n') for line in f]
     except IOError:
         return []
 

--- a/vr/common/templates/proc.conf
+++ b/vr/common/templates/proc.conf
@@ -1,7 +1,8 @@
 [program:%(container_name)s]
-command=%(runner)s run %(proc_yaml_path)s
+command=bash -c "if [[ -f %(proc_yaml_path)s ]] || [[ -f %(container_path)s ]] ; then %(runner)s run %(proc_yaml_path)s; fi"
 autostart=true
 autorestart=true
+startretries=3
 stdout_logfile=%(log)s
 stdout_logfile_maxbytes=10000000
 stdout_logfile_backups=1

--- a/vr/common/templates/proc.conf
+++ b/vr/common/templates/proc.conf
@@ -2,7 +2,7 @@
 command=bash -c "if [[ -f %(proc_yaml_path)s ]] || [[ -f %(container_path)s ]] ; then %(runner)s run %(proc_yaml_path)s; fi"
 autostart=true
 autorestart=true
-startretries=3
+startsecs = 2
 stdout_logfile=%(log)s
 stdout_logfile_maxbytes=10000000
 stdout_logfile_backups=1

--- a/vr/common/tests/test_repos.py
+++ b/vr/common/tests/test_repos.py
@@ -15,9 +15,11 @@ def _exists_exe(exe):
 skipif_nohg = pytest.mark.skipif(not _exists_exe('hg'), reason="no hg")
 skipif_nogit = pytest.mark.skipif(not _exists_exe('git'), reason="no hg")
 
+
 def _git_config():
     run('git config user.email "you@example.com"')
     run('git config --global user.name "Your Name"')
+
 
 @pytest.mark.xfail
 class TestHg(object):

--- a/vr/common/tests/test_repos.py
+++ b/vr/common/tests/test_repos.py
@@ -12,60 +12,12 @@ def _exists_exe(exe):
     return find_executable(exe) is not None
 
 
-skipif_nohg = pytest.mark.skipif(not _exists_exe('hg'), reason="no hg")
 skipif_nogit = pytest.mark.skipif(not _exists_exe('git'), reason="no hg")
 
 
 def _git_config():
     run('git config user.email "you@example.com"')
     run('git config --global user.name "Your Name"')
-
-
-@skipif_nohg
-class TestHg(object):
-
-    def test_hg_folder_detection(self):
-        with tmpdir():
-            folder = os.path.abspath('.hg')
-            run('mkdir -p %s' % folder)
-            assert repo.guess_folder_vcs(os.getcwd()) == 'hg'
-
-    # TODO: Run local git/hg servers so we don't have to call out over
-    # the network during tests.
-    def test_hg_clone(self):
-        url = 'https://bitbucket.org/btubbs/vr_python_example'
-        with tmpdir():
-            hgrepo = repo.Repo('hgrepo', url, 'hg')
-            hgrepo.clone()
-            assert hgrepo.get_url() == url
-
-    def test_hg_update_norev(self):
-        with tmprepo('hg_python_app.tar.gz', 'hg') as r:
-            # rev defaults to tip
-            r.update()
-            assert r.version == '802efadda217'
-
-    def test_hg_get_version(self):
-        rev = '496e15fd973f'
-        with tmprepo('hg_python_app.tar.gz', 'hg') as r:
-            r.update(rev)
-            assert r.version == rev
-
-    def test_hg_update(self):
-        newrev = '13b6ce1e234a'
-        oldrev = '496e15fd973f'
-        with tmprepo('hg_python_app.tar.gz', 'hg') as r:
-            r.update(newrev)
-            f = 'newfile'
-            assert os.path.isfile(f)
-
-            r.update(oldrev)
-            assert not os.path.isfile(f)
-
-    def test_basename_trailing_space(self):
-        # Catches https://bitbucket.org/yougov/velociraptor/issue/10/
-        url = "ssh://hg@bitbucket.org/yougov/velociraptor "
-        assert repo.basename(url) == 'velociraptor'
 
 
 @skipif_nogit

--- a/vr/common/tests/test_repos.py
+++ b/vr/common/tests/test_repos.py
@@ -12,12 +12,58 @@ def _exists_exe(exe):
     return find_executable(exe) is not None
 
 
+skipif_nohg = pytest.mark.skipif(not _exists_exe('hg'), reason="no hg")
 skipif_nogit = pytest.mark.skipif(not _exists_exe('git'), reason="no hg")
-
 
 def _git_config():
     run('git config user.email "you@example.com"')
     run('git config --global user.name "Your Name"')
+
+@pytest.mark.xfail
+class TestHg(object):
+
+    def test_hg_folder_detection(self):
+        with tmpdir():
+            folder = os.path.abspath('.hg')
+            run('mkdir -p %s' % folder)
+            assert repo.guess_folder_vcs(os.getcwd()) == 'hg'
+
+    # TODO: Run local git/hg servers so we don't have to call out over
+    # the network during tests.
+    def test_hg_clone(self):
+        url = 'https://bitbucket.org/btubbs/vr_python_example'
+        with tmpdir():
+            hgrepo = repo.Repo('hgrepo', url, 'hg')
+            hgrepo.clone()
+            assert hgrepo.get_url() == url
+
+    def test_hg_update_norev(self):
+        with tmprepo('hg_python_app.tar.gz', 'hg') as r:
+            # rev defaults to tip
+            r.update()
+            assert r.version == '802efadda217'
+
+    def test_hg_get_version(self):
+        rev = '496e15fd973f'
+        with tmprepo('hg_python_app.tar.gz', 'hg') as r:
+            r.update(rev)
+            assert r.version == rev
+
+    def test_hg_update(self):
+        newrev = '13b6ce1e234a'
+        oldrev = '496e15fd973f'
+        with tmprepo('hg_python_app.tar.gz', 'hg') as r:
+            r.update(newrev)
+            f = 'newfile'
+            assert os.path.isfile(f)
+
+            r.update(oldrev)
+            assert not os.path.isfile(f)
+
+    def test_basename_trailing_space(self):
+        # Catches https://bitbucket.org/yougov/velociraptor/issue/10/
+        url = "ssh://hg@bitbucket.org/yougov/velociraptor "
+        assert repo.basename(url) == 'velociraptor'
 
 
 @skipif_nogit


### PR DESCRIPTION
configure superivisor to fail if  specific files/directory don't exist.
remove mercurial test
change variable name because they cause tests to fail
 